### PR TITLE
Use input function visibility for `#[endpoint]` generated function 

### DIFF
--- a/axum-openapi3-derive/src/lib.rs
+++ b/axum-openapi3-derive/src/lib.rs
@@ -61,7 +61,7 @@ pub fn endpoint(
 
     let path_for_openapi = transform_route(&path);
 
-    let public = get_public_token(macro_args.public);
+    let public = get_public_token(&input_fn.vis);
 
     let output = quote! {
         #public fn #fn_name() -> (&'static str, axum::routing::MethodRouter < #state , std::convert::Infallible >)
@@ -167,11 +167,10 @@ fn get_state_token(fn_args: Vec<HandlerArgument>) -> proc_macro2::TokenStream {
     state
 }
 
-fn get_public_token(public: bool) -> proc_macro2::TokenStream {
-    let public: proc_macro2::TokenStream = if public {
-        "pub ".parse().unwrap()
-    } else {
-        "".parse().unwrap()
+fn get_public_token(public: &syn::Visibility) -> proc_macro2::TokenStream {
+    let public: proc_macro2::TokenStream = match public {
+        syn::Visibility::Public(_) => "pub ".parse().unwrap(),
+        _ => "".parse().unwrap(),
     };
     public
 }

--- a/axum-openapi3-derive/src/lib.rs
+++ b/axum-openapi3-derive/src/lib.rs
@@ -61,8 +61,10 @@ pub fn endpoint(
 
     let path_for_openapi = transform_route(&path);
 
+    let public = get_public_token(macro_args.public);
+
     let output = quote! {
-        fn #fn_name() -> (&'static str, axum::routing::MethodRouter < #state , std::convert::Infallible >)
+        #public fn #fn_name() -> (&'static str, axum::routing::MethodRouter < #state , std::convert::Infallible >)
         {
             #input_fn
 
@@ -163,6 +165,15 @@ fn get_state_token(fn_args: Vec<HandlerArgument>) -> proc_macro2::TokenStream {
         .unwrap_or("()");
     let state: proc_macro2::TokenStream = state.parse().unwrap();
     state
+}
+
+fn get_public_token(public: bool) -> proc_macro2::TokenStream {
+    let public: proc_macro2::TokenStream = if public {
+        "pub ".parse().unwrap()
+    } else {
+        "".parse().unwrap()
+    };
+    public
 }
 
 fn get_path_params_token(

--- a/axum-openapi3-derive/src/macro_arguments.rs
+++ b/axum-openapi3-derive/src/macro_arguments.rs
@@ -5,14 +5,12 @@ pub struct MacroArgs {
     pub method: http::Method,
     pub path: String,
     pub description: Option<String>,
-    pub public: bool,
 }
 impl Parse for MacroArgs {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut method = None;
         let mut path = None;
         let mut description = None;
-        let mut public = false;
 
         while !input.is_empty() {
             // Parse key-value pairs
@@ -57,19 +55,6 @@ impl Parse for MacroArgs {
                     },
                     _ => return Err(syn::Error::new(meta.path.span(), "Expected literal")),
                 };
-            } else if meta.path.is_ident("public") {
-                public = match meta.value {
-                    Expr::Lit(s) => match s.lit {
-                        Lit::Bool(lit) => lit.value,
-                        _ => {
-                            return Err(syn::Error::new(
-                                meta.path.span(),
-                                "Expected literal boolean",
-                            ))
-                        }
-                    },
-                    _ => return Err(syn::Error::new(meta.path.span(), "Expected literal boolean")),
-                }
             } else {
                 return Err(syn::Error::new(meta.path.span(), "Unexpected argument"));
             }
@@ -94,7 +79,6 @@ impl Parse for MacroArgs {
             method,
             path,
             description,
-            public,
         })
     }
 }

--- a/axum-openapi3-derive/src/macro_arguments.rs
+++ b/axum-openapi3-derive/src/macro_arguments.rs
@@ -5,12 +5,14 @@ pub struct MacroArgs {
     pub method: http::Method,
     pub path: String,
     pub description: Option<String>,
+    pub public: bool,
 }
 impl Parse for MacroArgs {
     fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
         let mut method = None;
         let mut path = None;
         let mut description = None;
+        let mut public = false;
 
         while !input.is_empty() {
             // Parse key-value pairs
@@ -55,6 +57,19 @@ impl Parse for MacroArgs {
                     },
                     _ => return Err(syn::Error::new(meta.path.span(), "Expected literal")),
                 };
+            } else if meta.path.is_ident("public") {
+                public = match meta.value {
+                    Expr::Lit(s) => match s.lit {
+                        Lit::Bool(lit) => lit.value,
+                        _ => {
+                            return Err(syn::Error::new(
+                                meta.path.span(),
+                                "Expected literal boolean",
+                            ))
+                        }
+                    },
+                    _ => return Err(syn::Error::new(meta.path.span(), "Expected literal boolean")),
+                }
             } else {
                 return Err(syn::Error::new(meta.path.span(), "Unexpected argument"));
             }
@@ -79,6 +94,7 @@ impl Parse for MacroArgs {
             method,
             path,
             description,
+            public,
         })
     }
 }


### PR DESCRIPTION
When declaring a handler function using the `#[endpoint]` macro, a function is generated by the macro. This function is implicitly private, i.e. the resulting function starts with `fn handler(/* .. */)`.
This makes it not possible to use the `endpoint` macro in another file than the file that declares the routing.

This PR makes it possible to declare handler function using the endpoint macro within modules by using the visibility for the input function.

This way, a function declared like this can be declared in a different module than the router.

```rust
// file: src/handlers/ping.rs
#[endpoint(
    method = "POST",
    path = "/api/ping",
    description = "Ping my server",
)]
pub async fn ping(
    State(scheduler): State<Arc<RwLock<Scheduler>>>,
    Json(payload): Json<PingServerRequest>,
) -> Result<Json<ApiResponse>, ApiError>  {/**/}


// file: src/api.rs
pub fn create_router(scheduler: Arc<RwLock<Scheduler>>) -> Router {
    let router = Router::new()
        .add(crate::handlers::ping())
        .with_state(scheduler);
    router
}
```